### PR TITLE
Fix File to import not found or unreadable: font-awesome-sprockets

### DIFF
--- a/app/assets/stylesheets/resque_web/bootstrap_and_overrides.css.scss.erb
+++ b/app/assets/stylesheets/resque_web/bootstrap_and_overrides.css.scss.erb
@@ -2,7 +2,6 @@
   =require twitter-bootstrap-static/bootstrap
   */
 
-@import "font-awesome-sprockets";
 @import "font-awesome";
 
 html {


### PR DESCRIPTION
Merge fix related to font-awesome-sprockets. Original issue here https://github.com/resque/resque-web/issues/162 